### PR TITLE
fix(Header): unify button labels

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -22,7 +22,7 @@ const links = [{
     </template>
 
     <template #right>
-      <UButton label="Log in" color="gray" to="/login" />
+      <UButton label="Sign in" color="gray" to="/login" />
       <UButton label="Sign up" icon="i-heroicons-arrow-right-20-solid" trailing color="black" to="/signup" class="hidden lg:flex" />
     </template>
 


### PR DESCRIPTION
Related to https://github.com/nuxt-ui-pro/landing/issues/18

Should we rename `login.vue` as `signin.vue`, although it may be a breaking change?
I'm not sure how version of this template is managed.

If we should avoid breaking changes, adding `signin.vue` with content of `login.vue` and let `login.vue` redirect to `signin.vue`.

What do you think?