### PR TITLE
chore: update compatibilityDate to 2026-06-30

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
     '/docs': { redirect: '/docs/getting-started', prerender: false }
   },
 
-  compatibilityDate: '2024-07-11',
+  compatibilityDate: '2026-06-30',
 
   nitro: {
     prerender: {


### PR DESCRIPTION
Updates the Nuxt `compatibilityDate` to today's date (2026-06-30).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Nuxt compatibility date to a newer supported value, helping keep the app aligned with the latest framework expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->